### PR TITLE
Modernize session guards and add mock payment flow

### DIFF
--- a/Tutorias/__tests__/paymentValidation.node.mjs
+++ b/Tutorias/__tests__/paymentValidation.node.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { validatePaymentForm, formatCardNumber, formatExpiry } from '../utils/paymentValidation.js';
+
+const futureYear = String(new Date().getFullYear() + 2).slice(-2);
+
+assert.equal(formatCardNumber('4242424242424242'), '4242 4242 4242 4242');
+assert.equal(formatExpiry('1229'), '12/29');
+
+const validErrors = validatePaymentForm({
+  cardholder: 'Maria Perez',
+  cardNumber: '4242 4242 4242 4242',
+  expiry: `12/${futureYear}`,
+  cvv: '123',
+  postcode: '11001',
+});
+assert.deepEqual(validErrors, {});
+
+const invalidErrors = validatePaymentForm({
+  cardholder: '',
+  cardNumber: '1234',
+  expiry: '01/20',
+  cvv: 'HOLA',
+  postcode: 'HOLA',
+});
+assert.ok(invalidErrors.cardholder);
+assert.ok(invalidErrors.cardNumber);
+assert.ok(invalidErrors.expiry);
+assert.ok(invalidErrors.cvv);
+assert.ok(invalidErrors.postcode);
+
+console.log('payment validation tests passed');

--- a/Tutorias/app/(tabs)/_layout.jsx
+++ b/Tutorias/app/(tabs)/_layout.jsx
@@ -1,14 +1,15 @@
 // Tab layout: controls the bottom tabs and guards access with cute alerts xd
 import { Tabs } from 'expo-router';
 import React from 'react';
-import { auth } from '../config/firebase';
 import { useTopAlert } from '../../components/TopAlert';
 import CustomTabBar from '../../components/CustomTabBar';
 import { IconSymbol } from '../../components/ui/IconSymbol';
+import { useSession } from '../../contexts/AuthContext';
 
 export default function TabLayout() {
   // We show a custom bottom bar and block tabs that need login
   const topAlert = useTopAlert();
+  const session = useSession();
 
   return (
     <Tabs
@@ -23,10 +24,10 @@ export default function TabLayout() {
           ),
           listeners: {
             tabPress: (e) => {
-              if (!auth.currentUser) {
+              if (!session.isAuthenticated) {
                 e.preventDefault();
                 topAlert.show(
-                  'Debes iniciar sesión/Registrarme para acceder a: Perfil',
+                  'Inicia sesión para abrir tu perfil',
                   'info'
                 );
               }
@@ -56,10 +57,10 @@ export default function TabLayout() {
           ),
           listeners: {
             tabPress: (e) => {
-              if (!auth.currentUser) {
+              if (!session.isAuthenticated) {
                 e.preventDefault();
                 topAlert.show(
-                  'Debes iniciar sesión/Registrarme para acceder a: Chats',
+                  'Inicia sesión para usar los chats',
                   'info'
                 );
               }

--- a/Tutorias/app/(tabs)/index.jsx
+++ b/Tutorias/app/(tabs)/index.jsx
@@ -1,7 +1,7 @@
 // Home screen aka vibes central xd
 // Shows hero banner, subject cards, and quick actions.
 // Teachers can go to Matricular from here to post their offer.
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useRouter } from "expo-router";
 import {
   View,
@@ -13,38 +13,20 @@ import {
   useWindowDimensions,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
-import { auth, db } from "../config/firebase";
+import { db } from "../config/firebase";
 import { doc, getDoc } from "firebase/firestore";
 import { useTopAlert } from "../../components/TopAlert";
+import { useSession } from "../../contexts/AuthContext";
 
 export default function HomeScreen() {
   const router = useRouter();
   const { height: windowHeight, width: windowWidth } = useWindowDimensions();
-  const [isAuthed, setIsAuthed] = useState(false);
-  const [authChecked, setAuthChecked] = useState(false);
-  const [role, setRole] = useState("");
-  const [uid, setUid] = useState("");
   const topAlert = useTopAlert();
-
-  useEffect(() => {
-    const { onAuthStateChanged } = require('firebase/auth');
-    const unsub = onAuthStateChanged(require('../config/firebase').auth, async (u) => {
-      setIsAuthed(!!u);
-      setUid(u?.uid || "");
-      if (u) {
-        try {
-          const ref = doc(db, 'users', u.uid);
-          const snap = await getDoc(ref);
-          const d = snap.data() || {};
-          setRole(d.role || "");
-        } catch {}
-      } else {
-        setRole("");
-      }
-      setAuthChecked(true);
-    });
-    return () => unsub();
-  }, []);
+  const session = useSession();
+  const isAuthed = session.isAuthenticated;
+  const authChecked = session.ready;
+  const role = session.role;
+  const uid = session.user?.uid || "";
 
   // Static list of subjects we show on the home feed
   const subjects = useMemo(
@@ -88,7 +70,7 @@ export default function HomeScreen() {
   const cardShown = useRef(Array(subjects.length).fill(false)).current;
   const scrollYRef = useRef(0);
 
-  const maybeAnimateVisible = () => {
+  const maybeAnimateVisible = useCallback(() => {
     const viewportBottom = windowHeight + scrollYRef.current;
     subjects.forEach((_, i) => {
       const cardY = cardYs[i];
@@ -101,7 +83,7 @@ export default function HomeScreen() {
         }).start();
       }
     });
-  };
+  }, [cardAnims, cardShown, cardYs, subjects, windowHeight]);
 
   // Animate cards when they enter the viewport (fade/slide in).
   const onScroll = (e) => {
@@ -113,7 +95,7 @@ export default function HomeScreen() {
   useEffect(() => {
     const id = requestAnimationFrame(() => maybeAnimateVisible());
     return () => cancelAnimationFrame(id);
-  }, [windowHeight]);
+  }, [maybeAnimateVisible]);
   // Detect small screens to adjust some styles
   const isSmall = windowHeight < 680 || windowWidth < 360;
   return ( // Main container view with background color

--- a/Tutorias/app/_layout.jsx
+++ b/Tutorias/app/_layout.jsx
@@ -3,15 +3,18 @@ import { Stack } from 'expo-router';
 import React from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { TopAlertProvider } from '../components/TopAlert';
+import { AuthProvider } from '../contexts/AuthContext';
 
 export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <TopAlertProvider>
+        <AuthProvider>
         <Stack screenOptions={{ headerShown: false }}>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="+not-found" />
         </Stack>
+        </AuthProvider>
       </TopAlertProvider>
     </SafeAreaProvider>
   );

--- a/Tutorias/app/agenda.jsx
+++ b/Tutorias/app/agenda.jsx
@@ -243,6 +243,11 @@ export default function AgendaScreen() {
               <Text style={styles.cardSubtitle}>Docente: {item.teacherDisplayName || item.teacherId}</Text>
               <Text style={styles.cardSlot}>{formatSlot(item.slot)}</Text>
               <Text style={styles.cardStatus}>Estado: {item.statusLabel}</Text>
+              {item.paymentStatus === 'paid_mock' && (
+                <View style={styles.paymentBadge}>
+                  <Text style={styles.paymentBadgeText}>Pago mock aprobado</Text>
+                </View>
+              )}
               {item._pendingSync && (
                 <View style={styles.syncBadge}>
                   <Text style={styles.syncBadgeText}>Pendiente por sincronizar</Text>
@@ -260,6 +265,11 @@ export default function AgendaScreen() {
               <Text style={styles.cardSubtitle}>Docente: {item.teacherDisplayName || item.teacherId}</Text>
               <Text style={styles.cardSlot}>{formatSlot(item.slot)}</Text>
               <Text style={styles.cardStatus}>Estado: {item.statusLabel}</Text>
+              {item.paymentStatus === 'paid_mock' && (
+                <View style={styles.paymentBadge}>
+                  <Text style={styles.paymentBadgeText}>Pago mock aprobado</Text>
+                </View>
+              )}
               {item._pendingSync && (
                 <View style={styles.syncBadge}>
                   <Text style={styles.syncBadgeText}>Pendiente por sincronizar</Text>
@@ -349,6 +359,11 @@ export default function AgendaScreen() {
               <Text style={styles.cardSubtitle}>Estudiante: {item.studentDisplayName || item.studentId}</Text>
               <Text style={styles.cardSlot}>{formatSlot(item.slot)}</Text>
               <Text style={styles.cardStatus}>Estado: {item.statusLabel}</Text>
+              {item.paymentStatus === 'paid_mock' && (
+                <View style={styles.paymentBadge}>
+                  <Text style={styles.paymentBadgeText}>Pago mock aprobado</Text>
+                </View>
+              )}
               {item._pendingSync && (
                 <View style={styles.syncBadge}>
                   <Text style={styles.syncBadgeText}>Pendiente por sincronizar</Text>
@@ -441,6 +456,15 @@ const styles = StyleSheet.create({
   },
   offlineBadgeText: { color: '#ffedd5', fontWeight: '700' },
   syncingText: { color: '#9ca3af', marginBottom: 10 },
+  paymentBadge: {
+    marginTop: 10,
+    paddingVertical: 5,
+    paddingHorizontal: 10,
+    borderRadius: 999,
+    backgroundColor: '#DCFCE7',
+    alignSelf: 'flex-start',
+  },
+  paymentBadgeText: { color: '#166534', fontWeight: '900', fontSize: 12 },
   syncBadge: {
     marginTop: 10,
     paddingVertical: 4,

--- a/Tutorias/app/inspect/[subject]/[offerId].jsx
+++ b/Tutorias/app/inspect/[subject]/[offerId].jsx
@@ -2,7 +2,8 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Image, ActivityIndicator } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { doc, getDoc, runTransaction, collection, query, where, onSnapshot, serverTimestamp, addDoc } from 'firebase/firestore';
+import { MaterialIcons } from '@expo/vector-icons';
+import { doc, getDoc, collection, query, where, onSnapshot } from 'firebase/firestore';
 import { db } from '../../config/firebase';
 import { useTopAlert } from '../../../components/TopAlert';
 import { useAuthGuard } from '../../../hooks/useAuthGuard';
@@ -175,7 +176,7 @@ export default function OfferDetailScreen() {
   return `${dayLabel} · ${hoursToLabel(slot.hourStart)} - ${hoursToLabel(slot.hourEnd)}`;
 };
 
-  const canBook = !loading && !submitting && !!selectedSlot && !hasPending && !hasConfirmed && !isOwnOffer;
+  const canBook = !loading && !submitting && !!selectedSlot && !hasPending && !hasConfirmed && !isOwnOffer && !connectivity.isOffline;
 
   const handleBook = async () => {
     if (!selectedSlot) {
@@ -184,6 +185,10 @@ export default function OfferDetailScreen() {
     }
     if (!user) {
       topAlert.show('Debes iniciar sesión para reservar', 'info');
+      return;
+    }
+    if (connectivity.isOffline) {
+      topAlert.show('Conéctate para completar el pago y confirmar tu solicitud.', 'info');
       return;
     }
     if (isOwnOffer) {
@@ -200,74 +205,16 @@ export default function OfferDetailScreen() {
     }
 
     setSubmitting(true);
-    let offerSnapshot = null;
-    try {
-      offerSnapshot = await runTransaction(db, async (transaction) => {
-        const offerRef = doc(db, OFFERS_COLLECTION, offerId);
-        const snap = await transaction.get(offerRef);
-        if (!snap.exists()) {
-          throw new Error('Oferta no disponible');
-        }
-        const data = snap.data() || {};
-        const max = Number(data.maxStudents || 0);
-        const enrolled = Number(data.enrolledCount || 0);
-        const pending = Number(data.pendingCount || 0);
-        const unlimitedOffer = max === 0;
-        if (!unlimitedOffer && enrolled + pending >= max) {
-          throw new Error('No hay cupos disponibles');
-        }
-        transaction.update(offerRef, {
-          pendingCount: pending + 1,
-          updatedAt: serverTimestamp(),
-        });
-        return data;
-      });
-
-      const reservationData = {
+    router.push({
+      pathname: '/payment/[offerId]',
+      params: {
         offerId,
-        subjectKey,
-        subjectName: offerSnapshot.subjectName || subjectName,
-        teacherId: offerSnapshot.uid,
-        studentId: user.uid,
-        status: RESERVATION_STATUS.PENDING,
-        slot: selectedSlot,
-        price: offerSnapshot.price || null,
-        studentDisplayName: user.displayName || user.email || '',
-        teacherDisplayName: offerSnapshot.username || offerSnapshot.teacherDisplayName || '',
-        createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp(),
-      };
-
-      await addDoc(collection(db, RESERVATIONS_COLLECTION), reservationData);
-
-      setOffer((prev) => (prev ? { ...prev, pendingCount: Number(prev.pendingCount || 0) + 1 } : prev));
-      topAlert.show('Solicitud enviada. Espera la confirmación del docente.', 'success');
-      router.push('/agenda');
-    } catch (error) {
-      if (offerSnapshot && error?.message !== 'No hay cupos disponibles') {
-        try {
-          await runTransaction(db, async (transaction) => {
-            const offerRef = doc(db, OFFERS_COLLECTION, offerId);
-            const snap = await transaction.get(offerRef);
-            if (!snap.exists()) return;
-            const data = snap.data() || {};
-            const pending = Number(data.pendingCount || 0);
-            transaction.update(offerRef, {
-              pendingCount: Math.max(0, pending - 1),
-              updatedAt: serverTimestamp(),
-            });
-          });
-        } catch (rollbackError) {
-          console.error('offer detail: rollback failed', rollbackError);
-        }
-      }
-      const message = error?.message === 'No hay cupos disponibles'
-        ? 'No hay cupos disponibles'
-        : 'No se pudo crear la reserva';
-      topAlert.show(message, 'error');
-    } finally {
-      setSubmitting(false);
-    }
+        subject: subjectKey,
+        name: subjectName,
+        slot: encodeURIComponent(JSON.stringify(selectedSlot)),
+      },
+    });
+    setSubmitting(false);
   };
 
   const handleUploadMaterial = useCallback(
@@ -389,6 +336,11 @@ export default function OfferDetailScreen() {
           <Text style={styles.alertText}>Reserva confirmada. Nos vemos en clase.</Text>
         </View>
       )}
+      {connectivity.isOffline && !isOwnOffer && (
+        <View style={styles.alertBox}>
+          <Text style={styles.alertText}>Estás sin conexión. Puedes revisar la oferta, pero el pago mock requiere conexión.</Text>
+        </View>
+      )}
       {isOwnOffer && (
         <View style={styles.alertBox}>
           <Text style={styles.alertText}>No puedes reservar una tutoría que tú mismo publicaste.</Text>
@@ -403,7 +355,7 @@ export default function OfferDetailScreen() {
         {submitting ? (
           <ActivityIndicator size="small" color="#1B1E36" />
         ) : (
-          <Text style={styles.bookBtnText}>Reservar</Text>
+          <Text style={styles.bookBtnText}>Reservar y pagar</Text>
         )}
       </TouchableOpacity>
 

--- a/Tutorias/app/payment/[offerId].jsx
+++ b/Tutorias/app/payment/[offerId].jsx
@@ -1,0 +1,229 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { View, Text, StyleSheet, TextInput, TouchableOpacity, ScrollView, ActivityIndicator } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { MaterialIcons } from '@expo/vector-icons';
+import { addDoc, collection, doc, getDoc, runTransaction, serverTimestamp } from 'firebase/firestore';
+import { db } from '../config/firebase';
+import { useAuthGuard } from '../../hooks/useAuthGuard';
+import { useTopAlert } from '../../components/TopAlert';
+import { OFFERS_COLLECTION, RESERVATIONS_COLLECTION, RESERVATION_STATUS } from '../../constants/firestore';
+import { digitsOnly, formatCardNumber, formatExpiry, validatePaymentForm } from '../../utils/paymentValidation';
+
+const dayLabels = { Mon: 'Mon', Tue: 'Tue', Wed: 'Wed', Thu: 'Thu', Fri: 'Fri', Sat: 'Sat', Sun: 'Sun', Lun: 'Lun', Mar: 'Mar', Mie: 'Mié', Jue: 'Jue', Vie: 'Vie', Sab: 'Sáb', Dom: 'Dom' };
+const hoursToLabel = (value) => `${Number(value || 0).toString().padStart(2, '0')}:00`;
+const formatSlot = (slot) => !slot ? 'Horario por definir' : `${dayLabels[slot.day] || slot.day} · ${hoursToLabel(slot.hourStart)} - ${hoursToLabel(slot.hourEnd)}`;
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default function MockPaymentScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const params = useLocalSearchParams();
+  const topAlert = useTopAlert();
+  const { user, ready } = useAuthGuard({ dest: 'Pago mock', delayMs: 200 });
+  const offerId = decodeURIComponent(params.offerId || '');
+  const subjectKey = decodeURIComponent(params.subject || '');
+  const subjectName = decodeURIComponent(params.name || subjectKey || 'Tutoría');
+
+  const [offer, setOffer] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [processing, setProcessing] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [errors, setErrors] = useState({});
+  const [form, setForm] = useState({ cardholder: '', cardNumber: '', expiry: '', cvv: '', postcode: '' });
+
+  const selectedSlot = useMemo(() => {
+    try {
+      return JSON.parse(decodeURIComponent(params.slot || ''));
+    } catch {
+      return null;
+    }
+  }, [params.slot]);
+
+  useEffect(() => {
+    let active = true;
+    async function loadOffer() {
+      try {
+        const snap = await getDoc(doc(db, OFFERS_COLLECTION, offerId));
+        if (active) setOffer(snap.exists() ? { id: snap.id, ...snap.data() } : null);
+      } catch (error) {
+        console.error('payment: load offer failed', error);
+        topAlert.show('No se pudo cargar el resumen de pago', 'error');
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    if (offerId) loadOffer();
+    return () => { active = false; };
+  }, [offerId, topAlert]);
+
+  const priceValue = Number(offer?.price || 0);
+  const priceLabel = priceValue > 0 ? `$${priceValue.toFixed(2)}` : 'Gratis';
+  const teacherName = offer?.username || offer?.teacherDisplayName || 'Docente';
+
+  const updateField = (field, value) => {
+    const formatters = {
+      cardNumber: formatCardNumber,
+      expiry: formatExpiry,
+      cvv: (next) => digitsOnly(next).slice(0, 4),
+      postcode: (next) => digitsOnly(next).slice(0, 10),
+      cardholder: (next) => next,
+    };
+    const nextForm = { ...form, [field]: formatters[field](value) };
+    setForm(nextForm);
+    setErrors(validatePaymentForm(nextForm));
+  };
+
+  const handlePay = async () => {
+    const nextErrors = validatePaymentForm(form);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+    if (!user || !offer) {
+      topAlert.show('Tu sesión u oferta ya no está disponible.', 'error');
+      return;
+    }
+
+    setProcessing(true);
+    try {
+      await sleep(900);
+      const offerSnapshot = await runTransaction(db, async (transaction) => {
+        const offerRef = doc(db, OFFERS_COLLECTION, offerId);
+        const snap = await transaction.get(offerRef);
+        if (!snap.exists()) throw new Error('Oferta no disponible');
+        const data = snap.data() || {};
+        if (data.uid === user.uid) throw new Error('No puedes reservar tu propia tutoría');
+        const max = Number(data.maxStudents || 0);
+        const enrolled = Number(data.enrolledCount || 0);
+        const pending = Number(data.pendingCount || 0);
+        if (max !== 0 && enrolled + pending >= max) throw new Error('No hay cupos disponibles');
+        transaction.update(offerRef, { pendingCount: pending + 1, updatedAt: serverTimestamp() });
+        return data;
+      });
+
+      const cardDigits = digitsOnly(form.cardNumber);
+      await addDoc(collection(db, RESERVATIONS_COLLECTION), {
+        offerId,
+        subjectKey,
+        subjectName: offerSnapshot.subjectName || subjectName,
+        teacherId: offerSnapshot.uid,
+        studentId: user.uid,
+        status: RESERVATION_STATUS.PENDING,
+        paymentStatus: 'paid_mock',
+        paymentProvider: 'mock',
+        mockPayment: {
+          last4: cardDigits.slice(-4),
+          amount: priceValue,
+          currency: 'USD',
+          paidAt: Date.now(),
+        },
+        slot: selectedSlot,
+        price: offerSnapshot.price || null,
+        studentDisplayName: user.displayName || user.email || '',
+        teacherDisplayName: offerSnapshot.username || offerSnapshot.teacherDisplayName || '',
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      });
+
+      setSuccess(true);
+      topAlert.show('Pago mock aprobado. Tu solicitud fue enviada.', 'success');
+      await sleep(700);
+      router.replace({ pathname: '/agenda', params: { tab: 'pending', paid: '1' } });
+    } catch (error) {
+      console.error('payment: submit failed', error);
+      topAlert.show(error?.message || 'No se pudo completar el pago mock', 'error');
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  if (!ready || loading) {
+    return <View style={[styles.center, { paddingTop: insets.top + 24 }]}><ActivityIndicator color="#FF8E53" /><Text style={styles.muted}>Preparando pago seguro...</Text></View>;
+  }
+
+  if (!offer) {
+    return <View style={[styles.center, { paddingTop: insets.top + 24 }]}><Text style={styles.title}>Oferta no encontrada</Text><TouchableOpacity style={styles.secondaryButton} onPress={() => router.back()}><Text style={styles.secondaryText}>Volver</Text></TouchableOpacity></View>;
+  }
+
+  return (
+    <ScrollView style={styles.screen} contentContainerStyle={{ paddingTop: insets.top + 16, paddingBottom: 36, paddingHorizontal: 16 }}>
+      <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}><Text style={styles.backText}>Volver</Text></TouchableOpacity>
+      <View style={styles.hero}>
+        <View style={styles.secureBadge}><MaterialIcons name="lock" size={16} color="#064E3B" /><Text style={styles.secureText}>Pago mock protegido · no guardamos tu tarjeta</Text></View>
+        <Text style={styles.title}>Completa tu reserva</Text>
+        <Text style={styles.subtitle}>Simula el pago y envía tu solicitud al docente en un solo flujo.</Text>
+      </View>
+
+      <View style={styles.grid}>
+        <View style={styles.formCard}>
+          {success && <View style={styles.successBox}><MaterialIcons name="check-circle" size={22} color="#16A34A" /><Text style={styles.successText}>Pago aprobado. Redirigiendo...</Text></View>}
+          <PaymentInput label="Nombre del titular" value={form.cardholder} onChangeText={(value) => updateField('cardholder', value)} error={errors.cardholder} placeholder="María Pérez" autoCapitalize="words" />
+          <PaymentInput label="Número de tarjeta" value={form.cardNumber} onChangeText={(value) => updateField('cardNumber', value)} error={errors.cardNumber} placeholder="4242 4242 4242 4242" keyboardType="number-pad" icon="credit-card" />
+          <View style={styles.row}>
+            <PaymentInput style={styles.rowInput} label="Expira" value={form.expiry} onChangeText={(value) => updateField('expiry', value)} error={errors.expiry} placeholder="MM/YY" keyboardType="number-pad" />
+            <PaymentInput style={styles.rowInput} label="CVV" value={form.cvv} onChangeText={(value) => updateField('cvv', value)} error={errors.cvv} placeholder="123" keyboardType="number-pad" secureTextEntry />
+          </View>
+          <PaymentInput label="Código postal" value={form.postcode} onChangeText={(value) => updateField('postcode', value)} error={errors.postcode} placeholder="11001" keyboardType="number-pad" />
+          <TouchableOpacity style={[styles.payButton, processing && styles.disabled]} onPress={handlePay} disabled={processing}>
+            {processing ? <ActivityIndicator color="#1B1E36" /> : <Text style={styles.payText}>Pagar {priceLabel}</Text>}
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryKicker}>Resumen</Text>
+          <Text style={styles.summaryTitle}>{subjectName}</Text>
+          <SummaryLine label="Docente" value={teacherName} />
+          <SummaryLine label="Horario" value={formatSlot(selectedSlot)} />
+          <SummaryLine label="Precio" value={priceLabel} strong />
+          <View style={styles.note}><MaterialIcons name="info" size={18} color="#F59E0B" /><Text style={styles.noteText}>El pago es simulado. Solo se guardan el estado del pago y los últimos 4 dígitos.</Text></View>
+        </View>
+      </View>
+    </ScrollView>
+  );
+}
+
+function PaymentInput({ label, error, icon, style, ...props }) {
+  return <View style={[styles.inputGroup, style]}><Text style={styles.label}>{label}</Text><View style={[styles.inputShell, error && styles.inputError]}>{icon && <MaterialIcons name={icon} size={18} color="#94A3B8" />}<TextInput style={styles.input} placeholderTextColor="#94A3B8" {...props} /></View>{error ? <Text style={styles.error}>{error}</Text> : null}</View>;
+}
+
+function SummaryLine({ label, value, strong }) {
+  return <View style={styles.summaryLine}><Text style={styles.summaryLabel}>{label}</Text><Text style={[styles.summaryValue, strong && styles.summaryStrong]}>{value}</Text></View>;
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: '#0F172A' },
+  center: { flex: 1, backgroundColor: '#0F172A', alignItems: 'center', justifyContent: 'center', padding: 20 },
+  muted: { color: '#CBD5E1', marginTop: 12 },
+  backBtn: { alignSelf: 'flex-start', backgroundColor: '#FEF3C7', paddingHorizontal: 14, paddingVertical: 9, borderRadius: 999, marginBottom: 14 },
+  backText: { color: '#1E293B', fontWeight: '800' },
+  hero: { backgroundColor: '#111827', borderRadius: 28, padding: 22, borderWidth: 1, borderColor: '#334155', marginBottom: 16 },
+  secureBadge: { alignSelf: 'flex-start', flexDirection: 'row', alignItems: 'center', gap: 7, backgroundColor: '#D1FAE5', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, marginBottom: 12 },
+  secureText: { color: '#064E3B', fontSize: 12, fontWeight: '800' },
+  title: { color: '#F8FAFC', fontSize: 28, fontWeight: '900' },
+  subtitle: { color: '#CBD5E1', marginTop: 8, lineHeight: 21 },
+  grid: { gap: 16 },
+  formCard: { backgroundColor: '#F8FAFC', borderRadius: 24, padding: 18, gap: 12 },
+  summaryCard: { backgroundColor: '#1E293B', borderRadius: 24, padding: 18, borderWidth: 1, borderColor: '#334155' },
+  inputGroup: { gap: 7, marginBottom: 4 },
+  label: { color: '#334155', fontWeight: '800' },
+  inputShell: { minHeight: 50, borderRadius: 14, borderWidth: 1, borderColor: '#CBD5E1', backgroundColor: '#FFFFFF', flexDirection: 'row', alignItems: 'center', paddingHorizontal: 12, gap: 8 },
+  inputError: { borderColor: '#EF4444', backgroundColor: '#FEF2F2' },
+  input: { flex: 1, color: '#0F172A', fontWeight: '700' },
+  error: { color: '#DC2626', fontSize: 12, fontWeight: '700' },
+  row: { flexDirection: 'row', gap: 12 },
+  rowInput: { flex: 1 },
+  payButton: { marginTop: 8, backgroundColor: '#FBBF24', borderRadius: 16, minHeight: 54, alignItems: 'center', justifyContent: 'center' },
+  payText: { color: '#1B1E36', fontWeight: '900', fontSize: 16 },
+  disabled: { opacity: 0.65 },
+  successBox: { flexDirection: 'row', alignItems: 'center', gap: 8, backgroundColor: '#DCFCE7', borderRadius: 14, padding: 12 },
+  successText: { color: '#166534', fontWeight: '800' },
+  summaryKicker: { color: '#FBBF24', fontWeight: '900', textTransform: 'uppercase', letterSpacing: 1 },
+  summaryTitle: { color: '#F8FAFC', fontSize: 22, fontWeight: '900', marginTop: 8, marginBottom: 14 },
+  summaryLine: { flexDirection: 'row', justifyContent: 'space-between', gap: 12, paddingVertical: 10, borderBottomWidth: 1, borderBottomColor: '#334155' },
+  summaryLabel: { color: '#CBD5E1' },
+  summaryValue: { color: '#F8FAFC', fontWeight: '800', flex: 1, textAlign: 'right' },
+  summaryStrong: { color: '#FBBF24', fontSize: 18 },
+  note: { marginTop: 16, flexDirection: 'row', alignItems: 'flex-start', gap: 8, backgroundColor: '#451A03', padding: 12, borderRadius: 14 },
+  noteText: { color: '#FEF3C7', flex: 1, lineHeight: 18 },
+  secondaryButton: { marginTop: 14, backgroundColor: '#FBBF24', borderRadius: 14, paddingHorizontal: 16, paddingVertical: 10 },
+  secondaryText: { color: '#1B1E36', fontWeight: '900' },
+});

--- a/Tutorias/contexts/AuthContext.jsx
+++ b/Tutorias/contexts/AuthContext.jsx
@@ -1,0 +1,165 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { onAuthStateChanged, getIdToken } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
+import { auth, db } from '../app/config/firebase';
+import { ensureOfflineReady, useConnectivity } from '../tools/offline';
+
+const CACHED_USER_KEY = 'auth:lastUserSnapshot';
+const AuthContext = createContext(null);
+
+const parseJSON = (value) => {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+};
+
+const decodeJwtPayload = (token) => {
+  if (!token) return null;
+  const parts = token.split?.('.') || [];
+  if (parts.length < 2) return null;
+  const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+  try {
+    if (typeof globalThis?.atob === 'function') {
+      return JSON.parse(globalThis.atob(padded));
+    }
+    if (typeof Buffer !== 'undefined') {
+      return JSON.parse(Buffer.from(padded, 'base64').toString('utf8'));
+    }
+  } catch (error) {
+    console.warn('AuthContext: failed to decode token payload', error);
+  }
+  return null;
+};
+
+const loadCachedUser = async () => {
+  try {
+    return parseJSON(await AsyncStorage.getItem(CACHED_USER_KEY));
+  } catch (error) {
+    console.warn('AuthContext: failed to load cached user', error);
+    return null;
+  }
+};
+
+const persistCachedUser = async (snapshot) => {
+  try {
+    if (!snapshot) {
+      await AsyncStorage.removeItem(CACHED_USER_KEY);
+      return;
+    }
+    await AsyncStorage.setItem(CACHED_USER_KEY, JSON.stringify(snapshot));
+  } catch (error) {
+    console.warn('AuthContext: failed to persist cached user', error);
+  }
+};
+
+const buildUserSnapshot = async (firebaseUser, previous = null) => {
+  if (!firebaseUser) return null;
+  let profile = {};
+  let tokenRole = null;
+
+  try {
+    const token = await getIdToken(firebaseUser, false);
+    const payload = decodeJwtPayload(token);
+    tokenRole = typeof payload?.role === 'string' ? payload.role : null;
+  } catch (error) {
+    console.warn('AuthContext: unable to inspect token claims', error);
+  }
+
+  try {
+    const snap = await getDoc(doc(db, 'users', firebaseUser.uid));
+    profile = snap.exists() ? snap.data() || {} : {};
+  } catch (error) {
+    console.warn('AuthContext: unable to load user profile', error);
+  }
+
+  return {
+    uid: firebaseUser.uid,
+    email: firebaseUser.email || profile.email || previous?.email || '',
+    displayName: firebaseUser.displayName || profile.username || profile.displayName || previous?.displayName || '',
+    username: profile.username || previous?.username || '',
+    role: profile.role || tokenRole || previous?.role || '',
+    photoURL: firebaseUser.photoURL || profile.photoURL || previous?.photoURL || null,
+    providerId: firebaseUser.providerId,
+    refreshedAt: Date.now(),
+  };
+};
+
+export function AuthProvider({ children }) {
+  const connectivity = useConnectivity();
+  const [state, setState] = useState({
+    status: 'loading',
+    user: null,
+    isOfflineUser: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    let active = true;
+    let unsubscribe = () => {};
+
+    const bootstrap = async () => {
+      await ensureOfflineReady().catch(() => {});
+      const cached = await loadCachedUser();
+
+      if (active && !auth.currentUser && cached && connectivity.isOffline) {
+        setState({ status: 'authenticated', user: cached, isOfflineUser: true, error: null });
+      }
+
+      unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+        if (!active) return;
+        if (!firebaseUser) {
+          if (cached && connectivity.isOffline) {
+            setState({ status: 'authenticated', user: cached, isOfflineUser: true, error: null });
+          } else {
+            await persistCachedUser(null);
+            setState({ status: 'anonymous', user: null, isOfflineUser: false, error: null });
+          }
+          return;
+        }
+
+        setState((prev) => ({ ...prev, status: 'loading', isOfflineUser: false }));
+        const snapshot = await buildUserSnapshot(firebaseUser, cached);
+        if (!active) return;
+        await persistCachedUser(snapshot);
+        setState({ status: 'authenticated', user: snapshot, isOfflineUser: false, error: null });
+      });
+    };
+
+    bootstrap().catch((error) => {
+      console.error('AuthContext: bootstrap failed', error);
+      if (active) setState({ status: 'error', user: null, isOfflineUser: false, error });
+    });
+
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, [connectivity.isOffline]);
+
+  const value = useMemo(
+    () => ({
+      ...state,
+      ready: state.status !== 'loading',
+      isAuthenticated: state.status === 'authenticated' && !!state.user,
+      role: String(state.user?.role || '').toLowerCase(),
+      isOffline: connectivity.isOffline,
+      lastOnlineAt: connectivity.lastOnlineAt,
+    }),
+    [connectivity.isOffline, connectivity.lastOnlineAt, state]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export const useSession = () => {
+  const value = useContext(AuthContext);
+  if (!value) {
+    throw new Error('useSession must be used inside AuthProvider');
+  }
+  return value;
+};

--- a/Tutorias/docs/flujo-uso.md
+++ b/Tutorias/docs/flujo-uso.md
@@ -1,0 +1,38 @@
+# Flujo de uso — Tutorias
+
+```mermaid
+flowchart LR
+  A[Inicio] --> B{Sesión activa?}
+  B -- No --> C[Login / Registro]
+  C --> D[Explorar materias]
+  B -- Sí --> D
+  D --> E[Ver ofertas por materia]
+  E --> F[Detalle de tutoría]
+  F --> G[Seleccionar horario]
+  G --> H[Pantalla de pago mock]
+  H --> I{Validación correcta?}
+  I -- No --> H
+  I -- Sí --> J[Pago mock aprobado]
+  J --> K[Reserva pendiente]
+  K --> L[Mis reservas / Agenda]
+```
+
+```mermaid
+flowchart LR
+  A[Inicio] --> B[Login docente]
+  B --> C[Dashboard / Home]
+  C --> D[Publicar oferta]
+  C --> E[Agenda docente]
+  E --> F[Solicitudes pendientes]
+  F --> G[Aceptar o rechazar]
+  G --> H[Reservas confirmadas]
+  H --> I[Subir materiales]
+  I --> J[Chat y seguimiento]
+```
+
+## Reglas principales
+
+- Las rutas privadas usan una sesión centralizada para evitar validaciones dispersas y parpadeos.
+- La reserva de estudiante ya no crea una solicitud antes del pago: primero valida horario, luego abre el pago mock y después crea la reserva con `paymentStatus: paid_mock`.
+- El modo offline conserva caché local, cola de sincronización y avisos visuales. Las operaciones que requieren pago se bloquean con un mensaje claro cuando no hay conexión.
+- El pago mock no almacena datos sensibles completos: solo conserva metadatos simulados y los últimos cuatro dígitos.

--- a/Tutorias/hooks/useAuthGuard.js
+++ b/Tutorias/hooks/useAuthGuard.js
@@ -1,172 +1,67 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { onAuthStateChanged, getIdToken } from 'firebase/auth';
+import { useCallback, useEffect, useRef } from 'react';
 import { useRouter } from 'expo-router';
 import { useFocusEffect } from '@react-navigation/native';
-import { auth } from '../app/config/firebase';
-import { ensureOfflineReady, useConnectivity } from '../tools/offline';
+import { useSession } from '../contexts/AuthContext';
 
-const CACHED_USER_KEY = 'auth:lastUserSnapshot';
-const noop = () => {};
-
-const parseJSON = (value) => {
-  if (!value) return null;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return null;
-  }
-};
-
-const decodeJwtPayload = (token) => {
-  if (!token) return null;
-  const parts = token.split?.('.') || [];
-  if (parts.length < 2) return null;
-  const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
-  try {
-    if (typeof globalThis?.atob === 'function') {
-      const decoded = globalThis.atob(padded);
-      return JSON.parse(decoded);
-    }
-    if (typeof Buffer !== 'undefined') {
-      const decoded = Buffer.from(padded, 'base64').toString('utf8');
-      return JSON.parse(decoded);
-    }
-  } catch (error) {
-    console.warn('useAuthGuard: failed to decode token payload', error);
-  }
-  return null;
-};
-
-const loadCachedUser = async () => {
-  try {
-    const raw = await AsyncStorage.getItem(CACHED_USER_KEY);
-    return parseJSON(raw);
-  } catch (error) {
-    console.warn('useAuthGuard: failed to load cached user', error);
-    return null;
-  }
-};
-
-const persistCachedUser = async (snapshot) => {
-  if (!snapshot) return AsyncStorage.removeItem(CACHED_USER_KEY);
-  try {
-    await AsyncStorage.setItem(CACHED_USER_KEY, JSON.stringify(snapshot));
-  } catch (error) {
-    console.warn('useAuthGuard: failed to persist cached user', error);
-  }
-};
-
-const buildSnapshot = async (firebaseUser, previous = null) => {
-  if (!firebaseUser) return null;
-  let role = previous?.role ?? null;
-  try {
-    const token = await getIdToken(firebaseUser, false);
-    const payload = decodeJwtPayload(token);
-    if (payload && typeof payload.role === 'string') {
-      role = payload.role;
-    }
-  } catch (error) {
-    console.warn('useAuthGuard: unable to inspect token claims', error);
-  }
-  return {
-    uid: firebaseUser.uid,
-    email: firebaseUser.email,
-    displayName: firebaseUser.displayName || previous?.displayName || '',
-    role,
-    providerId: firebaseUser.providerId,
-  };
-};
-
-// dest = name of the protected area (shown in alert), delayMs = small delay so it feels natural
 export function useAuthGuard(options = {}) {
-  const { dest = 'esta sección', delayMs = 400, requireAuth = true, loginPath = '/login' } = options;
+  const {
+    dest = 'esta sección',
+    delayMs = 250,
+    requireAuth = true,
+    loginPath = '/login',
+    roles,
+  } = options;
   const router = useRouter();
-  const { isOffline } = useConnectivity();
-  const cachedProfileRef = useRef(null);
-  const [user, setUser] = useState(() => auth.currentUser || null);
-  const [ready, setReady] = useState(false);
-  const [isOfflineUser, setIsOfflineUser] = useState(false);
+  const session = useSession();
   const timer = useRef(null);
 
+  const normalizedRoles = Array.isArray(roles)
+    ? roles.map((role) => String(role).toLowerCase())
+    : roles
+    ? [String(roles).toLowerCase()]
+    : [];
+
+  const hasRequiredRole =
+    normalizedRoles.length === 0 || normalizedRoles.includes(String(session.role || '').toLowerCase());
+
   const scheduleRedirect = useCallback(() => {
-    if (!requireAuth) return;
+    if (!requireAuth || session.status === 'loading') return;
     if (timer.current) clearTimeout(timer.current);
     timer.current = setTimeout(() => {
-      try {
-        router.replace(`${loginPath}?alert=needAuth&dest=${encodeURIComponent(dest)}`);
-      } catch {}
+      router.replace({ pathname: loginPath, params: { next: dest } });
     }, delayMs);
-  }, [dest, delayMs, loginPath, requireAuth, router]);
+  }, [delayMs, dest, loginPath, requireAuth, router, session.status]);
 
-  // Watch auth changes and schedule redirect if needed
   useEffect(() => {
-    let ignore = false;
-    let unsubscribe = noop;
-
-    const bootstrap = async () => {
-      await ensureOfflineReady().catch(noop);
-      if (ignore) return;
-
-      const cached = await loadCachedUser();
-      cachedProfileRef.current = cached;
-
-      if (!auth.currentUser && cached && requireAuth && isOffline) {
-        setUser(cached);
-        setIsOfflineUser(true);
-        setReady(true);
-      }
-
-      unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
-        if (ignore) return;
-
-        if (firebaseUser) {
-          setUser(firebaseUser);
-          setIsOfflineUser(false);
-          setReady(true);
-          const snapshot = await buildSnapshot(firebaseUser, cachedProfileRef.current);
-          cachedProfileRef.current = snapshot;
-          persistCachedUser(snapshot);
-        } else {
-          setReady(true);
-          if (requireAuth && cachedProfileRef.current && isOffline) {
-            setUser(cachedProfileRef.current);
-            setIsOfflineUser(true);
-          } else {
-            setUser(null);
-            setIsOfflineUser(false);
-            cachedProfileRef.current = null;
-            persistCachedUser(null);
-            scheduleRedirect();
-          }
-        }
-      });
-    };
-
-    bootstrap();
-
+    if (!requireAuth) return undefined;
+    if (session.status === 'anonymous' || session.status === 'error') {
+      scheduleRedirect();
+    }
     return () => {
-      ignore = true;
       if (timer.current) clearTimeout(timer.current);
-      unsubscribe();
     };
-  }, [isOffline, requireAuth, scheduleRedirect]);
+  }, [requireAuth, scheduleRedirect, session.status]);
 
-  // Re-check when the screen focuses again
   useFocusEffect(
     useCallback(() => {
-      if (!auth.currentUser && !cachedProfileRef.current && !isOfflineUser) scheduleRedirect();
+      if (requireAuth && (session.status === 'anonymous' || session.status === 'error')) {
+        scheduleRedirect();
+      }
       return () => {};
-    }, [scheduleRedirect, isOfflineUser])
+    }, [requireAuth, scheduleRedirect, session.status])
   );
 
   return {
-    user,
-    ready,
-    isAuthed: !!user,
-    isOfflineUser,
-    cachedUser: cachedProfileRef.current,
+    user: session.user,
+    ready: session.ready,
+    status: session.status,
+    isAuthed: session.isAuthenticated,
+    isAuthenticated: session.isAuthenticated,
+    isOfflineUser: session.isOfflineUser,
+    cachedUser: session.user,
+    role: session.role,
+    hasRequiredRole,
+    blockedByRole: session.isAuthenticated && !hasRequiredRole,
+    isOffline: session.isOffline,
   };
 }
-

--- a/Tutorias/package.json
+++ b/Tutorias/package.json
@@ -7,7 +7,9 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "node __tests__/paymentValidation.node.mjs",
+    "build": "expo export --platform web"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/Tutorias/utils/paymentValidation.js
+++ b/Tutorias/utils/paymentValidation.js
@@ -1,0 +1,64 @@
+export const digitsOnly = (value = '') => String(value).replace(/\D/g, '');
+
+export const formatCardNumber = (value = '') =>
+  digitsOnly(value)
+    .slice(0, 19)
+    .replace(/(.{4})/g, '$1 ')
+    .trim();
+
+export const formatExpiry = (value = '') => {
+  const digits = digitsOnly(value).slice(0, 4);
+  if (digits.length <= 2) return digits;
+  return `${digits.slice(0, 2)}/${digits.slice(2)}`;
+};
+
+const isFutureExpiry = (value = '') => {
+  const [monthRaw, yearRaw] = String(value).split('/');
+  const month = Number(monthRaw);
+  const year = Number(`20${yearRaw}`);
+  if (!monthRaw || !yearRaw || month < 1 || month > 12 || yearRaw.length !== 2) return false;
+  const now = new Date();
+  const expiryLimit = new Date(year, month, 0, 23, 59, 59, 999);
+  return expiryLimit >= now;
+};
+
+export const validatePaymentForm = (form = {}) => {
+  const errors = {};
+  const cardDigits = digitsOnly(form.cardNumber);
+  const cvvDigits = digitsOnly(form.cvv);
+  const postcodeDigits = digitsOnly(form.postcode);
+
+  if (!String(form.cardholder || '').trim()) {
+    errors.cardholder = 'Ingresa el nombre del titular.';
+  } else if (String(form.cardholder).trim().length < 3) {
+    errors.cardholder = 'El nombre debe tener al menos 3 caracteres.';
+  }
+
+  if (!cardDigits) {
+    errors.cardNumber = 'Ingresa el número de tarjeta.';
+  } else if (cardDigits.length < 13 || cardDigits.length > 19) {
+    errors.cardNumber = 'El número debe tener entre 13 y 19 dígitos.';
+  }
+
+  if (!String(form.expiry || '').trim()) {
+    errors.expiry = 'Ingresa la fecha de expiración.';
+  } else if (!/^\d{2}\/\d{2}$/.test(String(form.expiry)) || !isFutureExpiry(form.expiry)) {
+    errors.expiry = 'Usa una fecha válida en formato MM/YY.';
+  }
+
+  if (!cvvDigits) {
+    errors.cvv = 'Ingresa el CVV.';
+  } else if (cvvDigits.length < 3 || cvvDigits.length > 4) {
+    errors.cvv = 'El CVV debe tener 3 o 4 dígitos.';
+  }
+
+  if (!postcodeDigits) {
+    errors.postcode = 'Ingresa tu código postal.';
+  } else if (postcodeDigits.length < 4 || postcodeDigits.length > 10) {
+    errors.postcode = 'El código postal debe tener entre 4 y 10 números.';
+  }
+
+  return errors;
+};
+
+export const isPaymentFormValid = (form) => Object.keys(validatePaymentForm(form)).length === 0;


### PR DESCRIPTION
### Motivation
- Centralizar la gestión de sesión y evitar validaciones dispersas para reducir parpadeos y duplicación de lógica.
- Proteger y simplificar rutas por rol y estado (online/offline) con guards más mantenibles.
- Añadir un flujo de pago mock realista posterior a la reserva para simular pagos sin integrar pasarelas externas.
- Mejorar UX en flujos clave (reserva, agenda, perfil) y mantener compatibilidad con los módulos offline existentes.

### Description
- Se añadió un proveedor de sesión global `AuthProvider` y el hook `useSession` que unifica estado, perfil Firestore, rol y modo offline; el provider se monta en `app/_layout.jsx` para toda la app (`contexts/AuthContext.jsx`).
- Se refactorizó `useAuthGuard` para basarse en `useSession`, soportar roles opcionales y redirecciones limpias, y evitar validaciones por componente (`hooks/useAuthGuard.js`).
- El layout de tabs y la pantalla Home ahora usan la sesión centralizada para controlar accesos y mensajes en vez de consultar `auth.currentUser` directamente (`app/(tabs)/_layout.jsx`, `app/(tabs)/index.jsx`).
- Cambio de flujo de reserva: el botón ahora abre una nueva pantalla de pago mock en lugar de crear la reserva antes del pago; detalle de oferta bloquea pago cuando está offline y muestra aviso (`app/inspect/[subject]/[offerId].jsx`).
- Nueva pantalla de pago mock con UI moderna, validaciones, estados de loading/éxito y persistencia solo de metadatos no sensibles (`app/payment/[offerId].jsx`).
- Validaciones y utilidades reutilizables para el formulario de pago implementadas en `utils/paymentValidation.js` y tests básicos añadidos en `__tests__/paymentValidation.node.mjs`.
- Se añadió badge visual en Agenda para reservas con `paymentStatus: paid_mock`, documentación de flujo en `docs/flujo-uso.md` y scripts `test`/`build` en `package.json`.

### Testing
- `npm test` ejecutó `__tests__/paymentValidation.node.mjs` y pasó correctamente (valida formateo y reglas de pago). 
- `npm run lint` (expo lint) se ejecutó y completó; no hubo errores bloqueantes pero quedaron warnings preexistentes en algunos hooks/componentes (`profile`, `login`, `TopAlert`).
- `npm run build` (Expo export web) se ejecutó con éxito y generó las rutas estáticas (incluyendo `/payment/[offerId]`) sin fallos.
- `git diff --check` y las verificaciones internas se ejecutaron durante el flujo y no reportaron errores críticos; los tests unitarios añadidos pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa678694888322815b3dd806ed6077)